### PR TITLE
fix: added pycopg2 in requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ djangorestframework-camel-case==1.3.0
 drf-spectacular==0.22.1
 django-extensions==3.1.5
 django-environ==0.8.1
+psycopg2-binary==2.9.5


### PR DESCRIPTION
fix:
The template was throwing an error on attaching postgres

so mentioned 
psycopg2 in requirements.txt